### PR TITLE
fix/lib: Fix a private-in-public error

### DIFF
--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use image_lib::{DynamicImage, ImageBuffer, open, load_from_memory};
+use image_crate::{DynamicImage, ImageBuffer, open, load_from_memory};
 use {Set, Transformer};
 use transformer::TransformerError;
 pub use self::modifiers::*;

--- a/src/image/modifiers.rs
+++ b/src/image/modifiers.rs
@@ -1,5 +1,5 @@
 use modifier::Modifier;
-use image_lib::FilterType;
+use image_crate::FilterType;
 use super::Image;
 
 #[derive(Debug, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,17 +9,15 @@
         unsafe_code, unused_import_braces, unused_qualifications)]
 
 extern crate collenchyma as co;
-extern crate image as image_lib;
 extern crate murmurhash3 as murmur3;
+/// Re-export image crate.
+pub extern crate image as image_crate;
 
 pub use image::Image;
 pub use word::Word;
 pub use transformer::Transformer;
 
 pub use modifier::Set;
-
-/// Re-export image crate.
-pub use image_lib as image_crate;
 
 /// Transformer
 pub mod transformer;


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it was broken by a bugfix in rustc (see https://tools.taskcluster.net/task-inspector/#i63NpCZmTuqBzcD1fBNqzA/0 and rust-lang/rust#34537 for more details).
Here's a fix.
