### PR TITLE
Fix build on nightly

### DIFF
--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use image_lib::{DynamicImage, ImageBuffer, open, load_from_memory};
+use image_crate::{DynamicImage, ImageBuffer, open, load_from_memory};
 use {Set, Transformer};
 use transformer::TransformerError;
 pub use self::modifiers::*;

--- a/src/image/modifiers.rs
+++ b/src/image/modifiers.rs
@@ -1,5 +1,5 @@
 use modifier::Modifier;
-use image_lib::FilterType;
+use image_crate::FilterType;
 use super::Image;
 
 #[derive(Debug, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
         unsafe_code, unused_import_braces, unused_qualifications)]
 
 extern crate collenchyma as co;
-extern crate image as image_lib;
 extern crate murmurhash3 as murmur3;
 
 pub use image::Image;
@@ -19,7 +18,7 @@ pub use transformer::Transformer;
 pub use modifier::Set;
 
 /// Re-export image crate.
-pub use image_lib as image_crate;
+pub extern crate image as image_crate;
 
 /// Transformer
 pub mod transformer;


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/34537 for more information about the issue).
